### PR TITLE
use ubuntu 18.04 (for LTS)

### DIFF
--- a/CC7_Open62541/Dockerfile
+++ b/CC7_Open62541/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/ubuntu:16.10 
+FROM docker.io/ubuntu:18.04 
 
 MAINTAINER Quasar Development Team (https://github.com/quasar-team)
 


### PR DESCRIPTION
Hi folks, sorry - this merge is actually long overdue (I'd forgotten to push the changes to github). 

In fact this changes nothing: we're already using Ubuntu 18.04 for the CI builds - I'd already pushed the CI image based on ubuntu 18.04 to docker.io (and travis pulls the image from docker.io).

I commit the docker files just so we can rebuild our images if we need to. So, this is just me catching up on house keeping.

Cheers,
Ben