### PR TITLE
added CC7 open62541 dockerfile

### DIFF
--- a/CC7_Open62541/Dockerfile
+++ b/CC7_Open62541/Dockerfile
@@ -1,0 +1,40 @@
+#
+# ==Purpose of the image created from this dockerfile==
+# Provides an image for building quasar created OPC-UA servers from source
+# using the open62541 back-end
+#
+FROM gitlab-registry.cern.ch/linuxsupport/cc7-base
+
+MAINTAINER Quasar Development Team (http://github.com/quasar-team)
+
+RUN yum clean expire-cache \ 
+&& yum --assumeyes update && yum install --assumeyes \
+     wget \
+     gcc-c++ \
+     git \
+     make \
+     cmake \
+     xsd \
+     astyle \
+     java-1.8.0-openjdk \
+     libxml2-devel \
+     xerces-c-devel \
+     openssl-devel \
+     pysvn \
+     python-lxml \
+     python2-pip \
+&& pip install --upgrade pip && pip install enum34 \
+&& yum clean all
+
+#
+# Clean the 3rdPartySoftware directory, paranoid perhaps.
+#
+CMD rm-rf /3rdPartySoftware && mkdir /3rdPartySoftware
+
+#
+# Boost. Note we cannot use boost version distributed in epel repo. At time of writing
+# it's too old (v1.48), we require boost Log: only introduced in 1.54.
+# Copy zipped pre-built boost from docker build environment to  image
+#
+ADD boost_1_59_0.tar.gz /3rdPartySoftware
+ENV BOOST_HOME=/3rdPartySoftware/boost_1_59_0/


### PR DESCRIPTION
Another change that does not affect ATLAS nor quasar _directly_.

This is a dockerfile for building a CC7 image with the dependencies quasar needs, but (crucially) no unified automation toolkit. So, users of this image have to use open62541 as the OPC-UA back-end toolkit.

I intend to use this for CI builds of CAEN, ISEG (and, eventually Wiener) but anyone can use the dockerfile to build an image for testing etc. So, of general interest I think.