### PR TITLE
anagate dependenices added to linux docker image used for CI builds

### DIFF
--- a/CC7_UnifiedAutomation/Dockerfile
+++ b/CC7_UnifiedAutomation/Dockerfile
@@ -72,3 +72,9 @@ ENV BOOST_HOME=/3rdPartySoftware/boost_1_59_0/
 ADD boost_1_68_0.tar.gz /3rdPartySoftware
 ADD libsocketcan-devel-0.0.9-p0.cc7.x86_64.rpm /tmp/
 RUN yum install --assumeyes /tmp/libsocketcan-devel-0.0.9-p0.cc7.x86_64.rpm && yum clean all
+
+#
+# Anagate. Add dependencies from local zip file
+# zip file obtained from http://www.anagate.de/en/support/download.htm
+#
+ADD anagate-api-2.13.tar.gz /3rdPartySoftware

--- a/CC7_UnifiedAutomation/README.md
+++ b/CC7_UnifiedAutomation/README.md
@@ -11,5 +11,5 @@ Contents of the directory from which this docker image is built
 ├── Dockerfile  
 ├── libsocketcan-devel-0.0.9-p0.cc7.x86_64.rpm  
 ├── README.md  
-└── uasdkcppbundle-src-centos7.0-x86_64-gcc4.8.2-v1.5.6-361.tar.gz  
-  
+├── uasdkcppbundle-src-centos7.0-x86_64-gcc4.8.2-v1.5.6-361.tar.gz
+└── anagate-api-2.13.tar.gz


### PR DESCRIPTION
Anagate dependenices added to docker image used for CERN-only (CERN only because of commercially licensed unified automation SDK) Continuous Integration builds on gitlab.cern.ch